### PR TITLE
feat(our-porch): add business card email and data APIs

### DIFF
--- a/src/app/api/our-porch/business-card/route.ts
+++ b/src/app/api/our-porch/business-card/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  askClaudeAboutCard,
+  checkAuth,
+  imagesFromBody,
+  UpstreamError,
+} from "@/lib/our-porch/anthropic";
+
+export const runtime = "nodejs";
+
+const SYSTEM_PROMPT =
+  "You read business card photos and draft short, warm, professional follow-up emails. " +
+  "You may be given one or two images: the front and the back of the same card. " +
+  "Treat them as a single card and use information from both. " +
+  "Respond with ONLY a JSON object, no other text, matching exactly this shape: " +
+  '{"recipient_email": string | null, "subject": string, "body": string}. ' +
+  "Extract the recipient's email address from the card if present, otherwise null. " +
+  "Keep the email brief (3-5 sentences), reference the conversation naturally, and sign off simply.";
+
+export async function POST(req: NextRequest) {
+  const authError = checkAuth(req);
+  if (authError) return authError;
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  let images;
+  try {
+    images = imagesFromBody(body);
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+
+  const notes = typeof body?.conversationNotes === "string" ? body.conversationNotes.trim() : "";
+  const notesLine = notes
+    ? `Here's what we talked about: ${notes}`
+    : "No notes were recorded about the conversation.";
+  const sideNote =
+    images.length > 1
+      ? "Here are the front and back of a business card I was just given."
+      : "Here's a business card I was just given.";
+
+  let parsed: any;
+  try {
+    parsed = await askClaudeAboutCard({
+      images,
+      system: SYSTEM_PROMPT,
+      prompt: `${sideNote} ${notesLine} Draft a follow-up email.`,
+    });
+  } catch (e: any) {
+    console.error("[our-porch] Failed to draft follow-up email:", e);
+    return NextResponse.json(
+      { error: e?.message ?? "Failed to draft follow-up email" },
+      { status: e instanceof UpstreamError ? e.status : 502 }
+    );
+  }
+
+  if (typeof parsed.subject !== "string" || typeof parsed.body !== "string") {
+    return NextResponse.json(
+      { error: "AI response missing subject/body" },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({
+    recipient_email:
+      typeof parsed.recipient_email === "string" && parsed.recipient_email
+        ? parsed.recipient_email
+        : null,
+    subject: parsed.subject,
+    body: parsed.body,
+  });
+}

--- a/src/app/api/our-porch/extract-card/route.ts
+++ b/src/app/api/our-porch/extract-card/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  askClaudeAboutCard,
+  checkAuth,
+  imagesFromBody,
+  UpstreamError,
+} from "@/lib/our-porch/anthropic";
+
+export const runtime = "nodejs";
+
+const SYSTEM_PROMPT =
+  "You read business card photos and extract the contact's details. " +
+  "You may be given one or two images: the front and the back of the same card. " +
+  "Treat them as a single card and merge the information you find across both. " +
+  "Respond with ONLY a JSON object, no other text, matching exactly this shape: " +
+  '{"name": string | null, "email": string | null, "phone": string | null, ' +
+  '"address": string | null, "company": string | null, "title": string | null, ' +
+  '"notes": string | null}. ' +
+  "Use null for any field the card does not show — never guess or invent values. " +
+  "For phone, keep the digits and any leading +, dropping other punctuation. " +
+  "For address, join the street, city, state and postal code into one line. " +
+  "Put anything else noteworthy (tagline, website, social handles) in notes.";
+
+export async function POST(req: NextRequest) {
+  const authError = checkAuth(req);
+  if (authError) return authError;
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  let images;
+  try {
+    images = imagesFromBody(body);
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+
+  const sideNote =
+    images.length > 1
+      ? "These are the front and back of one business card."
+      : "This is a business card.";
+
+  let parsed: any;
+  try {
+    parsed = await askClaudeAboutCard({
+      images,
+      system: SYSTEM_PROMPT,
+      prompt: `${sideNote} Extract the contact details.`,
+    });
+  } catch (e: any) {
+    console.error("[our-porch] Failed to extract card details:", e);
+    return NextResponse.json(
+      { error: e?.message ?? "Failed to extract card details" },
+      { status: e instanceof UpstreamError ? e.status : 502 }
+    );
+  }
+
+  const str = (v: unknown) =>
+    typeof v === "string" && v.trim() ? v.trim() : null;
+
+  return NextResponse.json({
+    name: str(parsed.name),
+    email: str(parsed.email),
+    phone: str(parsed.phone),
+    address: str(parsed.address),
+    company: str(parsed.company),
+    title: str(parsed.title),
+    notes: str(parsed.notes),
+  });
+}

--- a/src/lib/our-porch/anthropic.ts
+++ b/src/lib/our-porch/anthropic.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+export const AI_MODEL = "claude-sonnet-4-5";
+
+export type CardImage = {
+  imageBase64: string;
+  mimeType: string;
+};
+
+/** An upstream failure carrying the status the client should receive. */
+export class UpstreamError extends Error {
+  status: number;
+  constructor(message: string, status = 502) {
+    super(message);
+    this.name = "UpstreamError";
+    this.status = status;
+  }
+}
+
+/**
+ * Verify the shared secret sent by the Our Porch app. Returns an error
+ * response to return directly, or null when the request is authorized.
+ */
+export function checkAuth(req: NextRequest): NextResponse | null {
+  const secret = process.env.OUR_PORCH_API_SECRET;
+  if (!secret || req.headers.get("x-our-porch-secret") !== secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: "Server missing ANTHROPIC_API_KEY" },
+      { status: 500 }
+    );
+  }
+  return null;
+}
+
+export function extractJson(text: string): any {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error("AI response did not contain JSON");
+  }
+  return JSON.parse(text.slice(start, end + 1));
+}
+
+/**
+ * Send one or more card images plus a text prompt to Claude and return the
+ * parsed JSON object from its reply.
+ */
+export async function askClaudeAboutCard({
+  images,
+  system,
+  prompt,
+  maxTokens = 1024,
+}: {
+  images: CardImage[];
+  system: string;
+  prompt: string;
+  maxTokens?: number;
+}): Promise<any> {
+  const content: any[] = images.map((img) => ({
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: img.mimeType,
+      data: img.imageBase64,
+    },
+  }));
+  content.push({ type: "text", text: prompt });
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-api-key": process.env.ANTHROPIC_API_KEY as string,
+    "anthropic-version": ANTHROPIC_VERSION,
+  };
+
+  // Identity-linked API keys must name the workspace the request acts in.
+  // Plain workspace-scoped keys don't need this, so it stays optional.
+  if (process.env.ANTHROPIC_WORKSPACE_ID) {
+    headers["anthropic-workspace-id"] = process.env.ANTHROPIC_WORKSPACE_ID;
+  }
+
+  const res = await fetch(ANTHROPIC_API_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: AI_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: "user", content }],
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    // Pass rate limiting / overload straight through so the app can tell
+    // "busy, retry shortly" apart from "the server is broken". Anthropic uses
+    // 529 for overloaded, which isn't a valid status to return to a client.
+    const status =
+      res.status === 429 ? 429 : res.status === 529 ? 503 : 502;
+    throw new UpstreamError(
+      `Anthropic API error (${res.status}): ${errText || res.statusText}`,
+      status
+    );
+  }
+
+  const data = await res.json();
+  const text = data?.content?.[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error("Unexpected AI response shape");
+  }
+  return extractJson(text);
+}
+
+/**
+ * Pull the card images out of a request body, accepting both the single-image
+ * shape and the {front, back} shape. Throws if nothing usable is present.
+ */
+export function imagesFromBody(body: any): CardImage[] {
+  const images: CardImage[] = [];
+  const push = (img: any) => {
+    if (img?.imageBase64 && img?.mimeType) {
+      images.push({ imageBase64: img.imageBase64, mimeType: img.mimeType });
+    }
+  };
+
+  push(body?.front);
+  push(body?.back);
+  if (images.length === 0) push(body);
+
+  if (images.length === 0) {
+    throw new Error("At least one card image (imageBase64 + mimeType) is required");
+  }
+  return images;
+}


### PR DESCRIPTION
Introduce two authenticated endpoints for business card workflows:
- /our-porch/business-card drafts short follow-up emails from card images and optional conversation notes using Claude, returning subject/body/recipient_email as JSON.
- /our-porch/extract-card extracts structured contact data (name, email, phone, address, company, title, notes) from front/back card images without guessing missing fields.